### PR TITLE
No need to roll your own `npm` scripts

### DIFF
--- a/src/main/frontend/npm
+++ b/src/main/frontend/npm
@@ -1,3 +1,0 @@
-#!/bin/sh
-PATH="$PWD/node/":$PATH
-node "node/node_modules/npm/bin/npm-cli.js" "$@"

--- a/src/main/frontend/npm.cmd
+++ b/src/main/frontend/npm.cmd
@@ -1,5 +1,0 @@
-@echo off
-setlocal
-set PATH=%~dp0node/;%PATH%
-node node/node_modules/npm/bin/npm-cli.js %*
-@echo on


### PR DESCRIPTION
Those scripts are taken automagically by the maven plugin from target/.